### PR TITLE
Allows base64 encoding of ContentData

### DIFF
--- a/PaymentStatementIntegrations.Tests/CrmInsertTest/CrmInsertTest.cs
+++ b/PaymentStatementIntegrations.Tests/CrmInsertTest/CrmInsertTest.cs
@@ -2,6 +2,7 @@
 using LogicAppUnit.Helper;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
+using PaymentStatementIntegrations.Tests.Helpers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -257,7 +258,7 @@ namespace PaymentStatementIntegrations.Tests.CrmInsertTest
 
         private static StringContent GetServiceBusMessage()
         {
-            return ContentHelper.CreateJsonStringContent(new
+            var json = new
             {
                 // The JSON must match the data structure used by the Service Bus trigger, this includes 'contentData' to represent the message content
                 contentData = new
@@ -280,12 +281,14 @@ namespace PaymentStatementIntegrations.Tests.CrmInsertTest
                 lockedUntilUtc = "9999-12-31T23:59:59.9999999Z",
                 lockToken = "056bb9fa-9b8f-4d93-874b-7e78e71a588d",
                 sequenceNumber = 980
-            });
+            };
+
+            return UnitTestHelper.EncodeAsStringContent(json);
         }
 
         private static StringContent GetServiceBusMessageInvalidSchemaJson()
         {
-            return ContentHelper.CreateJsonStringContent(new
+            var json = new
             {
                 // The JSON must match the data structure used by the Service Bus trigger, this includes 'contentData' to represent the message content
                 contentData = new
@@ -309,12 +312,14 @@ namespace PaymentStatementIntegrations.Tests.CrmInsertTest
                 lockedUntilUtc = "9999-12-31T23:59:59.9999999Z",
                 lockToken = "056bb9fa-9b8f-4d93-874b-7e78e71a588d",
                 sequenceNumber = 980
-            });
+            };
+
+            return UnitTestHelper.EncodeAsStringContent(json);
         }
 
         private static StringContent GetServiceBusMessageValidButMissingItemsJson()
         {
-            return ContentHelper.CreateJsonStringContent(new
+            var json = new
             {
                 // The JSON must match the data structure used by the Service Bus trigger, this includes 'contentData' to represent the message content
                 contentData = new
@@ -334,7 +339,9 @@ namespace PaymentStatementIntegrations.Tests.CrmInsertTest
                 lockedUntilUtc = "9999-12-31T23:59:59.9999999Z",
                 lockToken = "056bb9fa-9b8f-4d93-874b-7e78e71a588d",
                 sequenceNumber = 980
-            });
+            };
+
+            return UnitTestHelper.EncodeAsStringContent(json);
         }
     }
 }

--- a/PaymentStatementIntegrations.Tests/Helpers/UnitTestHelper.cs
+++ b/PaymentStatementIntegrations.Tests/Helpers/UnitTestHelper.cs
@@ -1,0 +1,37 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Text;
+
+namespace PaymentStatementIntegrations.Tests.Helpers
+{
+    /// <summary>
+    /// UnitTestHelper contains helper functions to be used in unit tests
+    /// </summary>
+	public class UnitTestHelper
+	{
+        /// <summary>
+        /// Create string contentOnly encode ContentData as base64 if flag set
+        /// </summary>
+        /// <param name="jsonObj">JSON object</param>
+        /// <param name="encodeAsBase64">A flag to denote if the contentData payload should be encoded in base 64</param>
+        /// <returns>String content</returns>
+        public static StringContent EncodeAsStringContent(object jsonObj, bool encodeAsBase64 = false)
+        {
+            var jsonStr = JsonConvert.SerializeObject(jsonObj);
+            if (!encodeAsBase64)
+            {
+                return new StringContent(jsonStr, Encoding.UTF8, "application/json");
+            }
+
+            var jObject = JObject.Parse(jsonStr);
+            var contentData = jObject["contentData"];
+            var temp1 = JsonConvert.SerializeObject(contentData);
+            var contentDataBytes = Encoding.Default.GetBytes(temp1);
+            var encodedContentData = Convert.ToBase64String(contentDataBytes);
+            jObject["contentData"] = encodedContentData;
+            return new StringContent(jObject.ToString(), Encoding.UTF8, "application/json");
+        }
+
+    }
+}
+

--- a/PaymentStatementIntegrations.Tests/PaymentStatementIntegrations.Tests.csproj
+++ b/PaymentStatementIntegrations.Tests/PaymentStatementIntegrations.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <None Remove="CrmInsertTest\" />
     <None Remove="CrmRetrievalTest\" />
+    <None Remove="Helpers\" />
   </ItemGroup>
 <ItemGroup>
     <None Update="testConfiguration.json">
@@ -32,5 +33,6 @@
 <ItemGroup>
   <Folder Include="CrmInsertTest\" />
   <Folder Include="CrmRetrievalTest\" />
+  <Folder Include="Helpers\" />
 </ItemGroup>
 </Project>


### PR DESCRIPTION
If using a Service Bus polling trigger, the ContentData section of the received message is base64 encoded. Therefore allow unit tests to handle this scenario